### PR TITLE
Issue 180, 58, 193, 218 and 155

### DIFF
--- a/pymel/core/general.py
+++ b/pymel/core/general.py
@@ -588,7 +588,7 @@ Modifications:
 
 def addAttr( *args, **kwargs ):
     """
-Modifications:
+    Modifications:
   - allow python types to be passed to set -at type
             str         string
             float       double
@@ -607,9 +607,32 @@ Modifications:
         >>> addAttr('persp.test', edit=1, hasMaxValue=True)
         >>> addAttr('persp.test', query=1, hasMaxValue=True)
         True
-
+   -Allow user to pass in type and determine whether it is a dataType or attributeType.
+    Right now float2, float3, double2, double3, long2, long3, short2, and short3 are all treated
+    as attributeTypes.
     """
+    attributeTypes = [ 'bool', 'long', 'short', 'byte', 'char', 'enum',
+                       'float', 'double', 'doubleAngle', 'doubleLinear',
+                       'compound', 'message', 'time', 'fltMatrix', 'reflectance',
+                       'spectrum', 'float2', 'float3', 'double2', 'double3', 'long2',
+                       'long3', 'short2', 'short3' ]
+
+    dataTypes = [ 'string', 'stringArray', 'matrix', 'reflectanceRGB',
+                  'spectrumRGB', 'doubleArray', 'Int32Array', 'vectorArray',
+                  'nurbsCurve', 'nurbsSurface', 'mesh', 'lattice', 'pointArray' ]
+    
+    type = kwargs.pop('type', kwargs.pop('typ', None ))
+    
+    if type is not None:
+        if type in attributeTypes:
+            kwargs['at'] = type
+        elif type in dataTypes:
+            kwargs['dt'] = type
+        else:
+            raise TypeError, "type not supported"
+    
     at = kwargs.pop('attributeType', kwargs.pop('at', None ))
+    
     if at is not None:
         try:
             kwargs['at'] = {


### PR DESCRIPTION
Added a note to the docs to run cmd as administrator in Windows Vista and above.

Fixed __pymelUndoNode to be created in the root namespace

mel2py now outputs same filename as input on Windows.  path.canonicalpath was edited accept a parameter normcase=True.  If set to True abspath().realpath().normpath().normcase() is executed.  If set to False the same is exeuted + normcase().  Edited mel2py.__init__.resolvePath to append the non normcase() version of the file.

Added pyMel unique flag preserveNamespace to DependNode.rename.  While adding that also added the ability to pass rename flags such as ignoreShape.  Finally added a check to ensure that shortnames are used when calling DependNode.rename.

Added ability to pass type to addAttr.  The type is automatically determined to be a dataType or an attributeType.  Right now any conflicting types ie float3 are treated as attributeTypes.  The user can still pass at or dt if they prefer.