### PR TITLE
Fixed pymel.core.system.referenceQuery function

### DIFF
--- a/pymel/core/system.py
+++ b/pymel/core/system.py
@@ -1566,6 +1566,8 @@ def referenceQuery(*args, **kwargs):
                                         failedEdits = not mode,
                                         successfulEdits = mode,
                                         **kwargs)
+            if edits is None:
+                edits = []
             allEdits.extend(ReferenceEdit(edit, fr, mode) for edit in edits)
         return allEdits
     else:

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -556,6 +556,15 @@ class testCase_references(unittest.TestCase):
         self.assertEqual(sphereInCubeInConeRef.refNode.namespace(),
                          'cone1:cubeInCone:')
 
+    def test_live_edits_returning_an_empty_list(self):
+        """testing if the le=True or liveEdits=True with no reference edit will
+        return an empty list
+        """
+        # create a new reference with no edits
+        ref = pm.createReference(self.sphereFile, namespace='sphere')
+        edits = pm.referenceQuery(ref, es=1, le=1)
+        self.assertEqual(edits, [])
+
 class testCase_fileInfo(unittest.TestCase):
     def setUp(self):
         pm.newFile(f=1)


### PR DESCRIPTION
Fixed pymel.core.system.referenceQuery function when editStrings and liveEdits flags are given as True the maya.cmds was returning None in which pymel was failing to extend the allEdits variable later on by raising a RuntimeError, now it fixes the edits variable by setting it to and empty list if it is None.
