### PR TITLE
return empty path for untitled string instead of /path/to/untitled.mb

### DIFF
--- a/pymel/core/system.py
+++ b/pymel/core/system.py
@@ -130,10 +130,11 @@ def sceneName():
     # because it was sometimes returning an empty string,
     # even when there was a valid file
     name = Path(_OpenMaya.MFileIO.currentFile())
-    if name.basename() == untitledFileName() and \
+    if name.basename().startswith(untitledFileName()) and \
             cmds.file(q=1, sceneName=1) == '':
         return Path()
-    return name
+    else:
+        return name
 
 def untitledFileName():
     """


### PR DESCRIPTION
I *think* this is a bug, but currently pm.sceneName() on an untitled scene returns Path('/path/to/untitled.mb') instead of Path(''). This is because _mel.eval('untitledFilename()') returns u'untitled', with no extension, so the comparison fails.

Here's a patch that fixes this.

cheers,
-Mark