### PR TITLE
This is a pull request for a change I already discussed with Chad. Ca…

### DIFF
--- a/pymel/api/plugins.py
+++ b/pymel/api/plugins.py
@@ -1011,7 +1011,7 @@ UNREPORTED_COMMANDS = {
     'modelEditorCommand': {'stereoCamera': ['stereoCameraView']},
     'controlCommand': {},
     'constraintCommand': {},
-    'contextCommand': {},  # currently no pluginInfo flag for this in any version, but I'm an optimist...
+    'tool': {},  # Tool replacing contextCommand to match Maya implementation
     #'other':{}, # just to hold any commands we may want that don't fall in other categories
 }
 


### PR DESCRIPTION
This is a pull request for a change I already discussed with Chad. Can you guys take a look at it please? Thanks!

PS: this is my first GitHub pull request, please let me know if I did something wrong!!

=== original e-mail ===

We recently investigated the exceptions that are thrown when we launch Maya and found out that there is one exception coming from a PyMEL script. In pymel/api/plugins.py, we found that you are trying to pass a non-existing flag to the pluginInfo command. The flag is:
'contextCommand': {}, # currently no pluginInfo flag for this in any version, but I'm an optimist...

We investigated the matter, and found out that the ‘tool’ flag is doing what you probably are looking for. It will return the tool context commands. I have to admit the flag name is a bit confusing, and maybe you thought that it would return the tool commands proper. It turns out that tool commands are already part of the “regular” commands and are returned when you use the ‘command’ flag (you already do).
So long story short we replaced ‘contextCommand’ with ‘tool’ in plugins.py on our side, and it got rid of that one exception.