### PR TITLE
UI modules cannot be imported when Maya runs in batch mode

### DIFF
--- a/pymel/all.py
+++ b/pymel/all.py
@@ -30,7 +30,10 @@ import versions
 
 from core import nodetypes
 from core.nodetypes import *
-from core.uitypes import *
+
+# if in batch mode we may not have UI commands
+if not cmds.about(batch=True):
+    from core.uitypes import *
 
 # These two were imported into 'old' pymel top level module,
 # so make sure they're imported here as well


### PR DESCRIPTION
Hi, we needed to bracket this import in order for Maya batch to run PyMEL properly. Importing UI-related components when running in Batch mode will result in unpredictable behavior / exceptions / crashes.