### PR TITLE
Fix issue #311, #350, #358

### DIFF
--- a/maya/utils.py
+++ b/maya/utils.py
@@ -92,8 +92,16 @@ def runOverriddenModule(modName, callingFileFunc, globals):
         if isinstance(findResults[0], file):
             findResults[0].close()
         # ...then check if the found file matched the callingFile
-        if os.path.samefile(findResults[1], callingFile):
-            break
+        try:
+            if os.path.samefile(findResults[1], callingFile):
+                break
+        except AttributeError:
+            # os.samefile does not exist on Windows (as of Python version < 3k)
+            # WARNING: Resorting to a less than ideal method to checking for same file
+            # TODO: Add deeper implementation of the samefile hack for windows
+            # in future, if possible.
+            if os.stat(findResults[1]) == os.stat(callingFile):
+                break
     else:
         # we couldn't find the file - raise an ImportError
         raise ImportError("Couldn't find the file %r when using path %r"

--- a/pymel/core/general.py
+++ b/pymel/core/general.py
@@ -5845,7 +5845,7 @@ class ParticleComponent(Component1D):
 
     def attr(self, attr):
         try:
-            return cmds.particle(self._node, q=1, attribute=attr, order=self._currentFlatIndex)
+            return cmds.particle(self._node, q=1, attribute=attr, order=super(ParticleComponent, self).currentItemIndex())
         except RuntimeError:
             raise MayaParticleAttributeError('%s.%s' % (self, attr))
 

--- a/pymel/core/nodetypes.py
+++ b/pymel/core/nodetypes.py
@@ -1678,7 +1678,7 @@ class Shape(DagNode):
     __metaclass__ = _factories.MetaMayaNodeWrapper
 
     def getTransform(self):
-        pass
+        return self.getParent(generations=1)
 
     def setParent(self, *args, **kwargs):
         if 'shape' not in kwargs and 's' not in kwargs:

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1106,6 +1106,17 @@ class test_PyNodeWraps(unittest.TestCase):
             cmds.setToolTo('artAttrCtx1')
             self.assertPyNodes(artAttrCtx('artAttrCtx1', q=1, paintNodeArray=1))
 
+class test_ParticleComponent(unittest.TestCase):
+    def setUp(self):
+        self.partTr, self.partShape = pm.particle(p=[(0, 0, 0), (1, 2, 3)])
+
+    def test_attr_position(self):
+        self.assertEqual(self.partShape.pt[0].position, [0, 0, 0])
+        self.assertEqual(self.partShape.pt[1].position, [1, 2, 3])
+
+    def tearDown(self):
+        pm.delete([self.partShape, self.partTr])
+
 for cmdName in ('''aimConstraint geometryConstraint normalConstraint
                    orientConstraint parentConstraint pointConstraint
                    pointOnPolyConstraint poleVectorConstraint

--- a/tests/test_nodetypes.py
+++ b/tests/test_nodetypes.py
@@ -1895,6 +1895,17 @@ class testCase_DagNode(TestCaseExtended):
             setB[x].overrideVisibility.set(0)
             self.assertFalse(setB[x].isVisible())
 
+class testCase_Shape(TestCaseExtended):
+    def setUp(self):
+        self.trans, self.polySphere = pm.polySphere()
+        self.shape = self.trans.getShape()
+
+    def test_getTransform(self):
+        self.assertEqual(self.shape.getTransform(), self.trans)
+
+    def tearDown(self):
+        pm.delete(self.trans)
+
 class testCase_transform(TestCaseExtended):
     def setUp(self):
         self.trans = pm.createNode('transform')


### PR DESCRIPTION
This is to address issue #311 by having ```getTransform()``` return ```getParent(generations=1)``` instead of nothing. For completeness.