### PR TITLE
add *args to FileReference.getReferenceEdits, command accepts target arguments

### DIFF
--- a/pymel/core/system.py
+++ b/pymel/core/system.py
@@ -1533,7 +1533,7 @@ class FileReference(object):
                                onReferenceNode=self.refNode, **kwargs)
         return edits
 
-    def removeReferenceEdits(self, editCommand=None, force=False, **kwargs):
+    def removeReferenceEdits(self, *args, **kwargs):
         """Remove edits from the reference.
 
         Parameters
@@ -1550,7 +1550,7 @@ class FileReference(object):
 
         Notes
         -----
-        By default, removes all edits. If neither of successfulEdits or
+        Removes all edits if no arguments are passed. If neither of successfulEdits or
         failedEdits is given, they both default to True. If only one is given,
         the other defaults to the opposite value. This will only succeed on
         unapplied edits (ie, on unloaded nodes, or failed edits)... However,
@@ -1559,16 +1559,17 @@ class FileReference(object):
         future, however...
         """
 
+        force = kwargs.pop('force', None)
+
         if force and self.isLoaded():
             self.unload()
-
-        if editCommand:
-            kwargs['editCommand'] = editCommand
 
         _translateEditFlags(kwargs)
         kwargs.pop('r', None)
         kwargs['removeEdits'] = True
-        cmds.referenceEdit(str(self.refNode), **kwargs)
+        if not args:
+            args = [str(self.refNode)]
+        cmds.referenceEdit(*args, **kwargs)
 
 def _translateEditFlags(kwargs, addKwargs=True):
     '''Given the pymel values for successfulEdits/failedEdits (which may be


### PR DESCRIPTION
This patch restores functionality available to cmds.referenceEdit that allows you to remove reference edits for a single node or attribute. This can be seen in action by removing reference edits via the "List Reference Edits..." UI, for example:

    referenceEdit -failedEdits true -successfulEdits true -editCommand connectAttr -removeEdits "|sulins_lizard_head_01:master_geo|sulins_lizard_head_01:sulin_GEO|sulins_lizard_head_01:sulin_GEOShape.instObjGroups";

Instead of the reference node, the attribute (or node) is passed as the argument.

If no argument is passed, the original behaviour of removing all edits is preserved, so this patch should be backwards-compatible.