### PR TITLE
Fix error messages while parsing plug-ins

### DIFF
--- a/pymel/core/__init__.py
+++ b/pymel/core/__init__.py
@@ -120,7 +120,11 @@ def _pluginLoaded(*args):
 
     if not pluginName:
         return
-
+    
+    # Check to see if plugin is really loaded
+    if not (cmds.pluginInfo(pluginName, query=1, loaded=1)): 
+        return
+        
     _logger.debug("Plugin loaded: %s", pluginName)
     _pluginData[pluginName] = {}
 


### PR DESCRIPTION
Pymel was printing a lot of errors when plugins failed to load:

<br># Error: pymel : Failed to get controlCommand list from resolverPluginDuplicate #
<br># Error: pymel : Failed to get modelEditorCommand list from resolverPluginDuplicate #
<br># Error: pymel : Failed to get tool list from resolverPluginDuplicate #
<br># Error: pymel : Failed to get command list from resolverPluginDuplicate #
<br># Error: pymel : Failed to get constraintCommand list from resolverPluginDuplicate #
<br># Error: pymel.core : Failed to get depend nodes list from resolverPluginDuplicate #

This change adds a test to validate that the plug-in was successfully loaded before processing its contents