### PR TITLE
Fix for #349: textField loses its type.

### DIFF
--- a/pymel/core/uitypes.py
+++ b/pymel/core/uitypes.py
@@ -1292,7 +1292,8 @@ _uiTypesToCommands = {
     'TcolorIndexSlider': 'rowLayout',
     'TcolorSlider': 'rowLayout',
     'floatingWindow': 'window',
-    'field': 'textField'
+    'field': 'textField',
+    'staticText': 'text'
 }
 
 dynModule._lazyModule_update()

--- a/pymel/core/uitypes.py
+++ b/pymel/core/uitypes.py
@@ -1291,7 +1291,9 @@ _uiTypesToCommands = {
     'rowGroupLayout': 'rowLayout',
     'TcolorIndexSlider': 'rowLayout',
     'TcolorSlider': 'rowLayout',
-    'floatingWindow': 'window'
+    'floatingWindow': 'window',
+    'field': 'textField'
 }
 
 dynModule._lazyModule_update()
+


### PR DESCRIPTION
objectTypeUI returns 'field' instead of textField. So they _uiTypesToCommands dictionary needed to be updated.