### PR TITLE
Python root logging level set to DEBUG

### DIFF
--- a/pymel/internal/plogging.py
+++ b/pymel/internal/plogging.py
@@ -107,6 +107,7 @@ def pymelLogFileConfig(fname, defaults=None, disable_existing_loggers=False):
     # root logger, and any other handlers specified... to override
     # this, save the existing handlers first
     root = logging.root
+    root_logger_level = root.level  # restore root level below if NOTSET
     # make sure you get a COPY of handlers!
     rootHandlers = root.handlers[:]
     oldLogHandlers = {}
@@ -153,6 +154,12 @@ def pymelLogFileConfig(fname, defaults=None, disable_existing_loggers=False):
                 oldHandlers = oldLogHandlers.get(logName)
             if oldHandlers:
                 _addOldHandlers(logger, oldHandlers, secName, cp)
+
+        # if root logger level not explicitly set in the pymel.conf file,
+        # then set it back to the original value.  The root logger always
+        # has to have a level.
+        if logging.root.level == logging.NOTSET:
+            logging.root.setLevel(root_logger_level)
 
     finally:
         logging._releaseLock()


### PR DESCRIPTION
The logging module states that the root logger has to have a level specified. In the logging module, root = Logger(WARNING). However in the pymel.conf file, logger_root level is set to NOTSET.
[logger_root]
level=NOTSET
handlers=
remove_existing_handlers=False
Options:
Modify the pymel.conf file to set logger_root level=WARNING
Modify pymel.plogging.pymelLogFileConfig() to set the root logger back to the original level (if set to NOTSET)
Option2 should be more robust and allow for user configurable pymel.conf files while correcting the bug in the root logger level.
Here is the code to add to plogging.py
    root_logger_level = root.level   # store off the root logger level, to restore back at the bottom of this function

        # if root logger level not explicitly set in the pymel.conf file,
        # then set it back to the original value.  The root logger always
        # has to have a level.
        if logging.root.level == logging.NOTSET:

JIRA #MAYA-67049