### PR TITLE
added mergeNamespaceWithParent and mergeNamespaceWithRoot 

### DIFF
--- a/pymel/core/system.py
+++ b/pymel/core/system.py
@@ -1416,8 +1416,10 @@ class FileReference(object):
 #        return cmds.file( self.withCopyNumber(), **kwargs )
 
     @_factories.addMelDocs('file', 'removeReference')
-    def remove(self):
-        return cmds.file(rfn=self.refNode, removeReference=1)
+    def remove(self, mergeNamespaceWithParent=False, mergeNamespaceWithRoot=False):
+        return cmds.file(rfn=self.refNode, removeReference=1,
+                         mergeNamespaceWithParent=mergeNamespaceWithParent,
+                         mergeNamespaceWithRoot=mergeNamespaceWithRoot)
 
 #    @_factories.addMelDocs('file', 'unloadReference')
 #    def unload(self):


### PR DESCRIPTION
... to FileReference.remove to match docs:

> remove()
> Remove the given file reference from its parent. This will also Remove everything this file references. Returns the name of the file removed. If the reference is alone in its namespace, remove the namespace. If there are objects remaining in the namespace after the file reference is removed, by default, keep the remaining objects in the namespace. To merge the objects remaining in the namespace to the parent or root namespace, **use flags mergeNamespaceWithParent or mergeNamespaceWithRoot**. The empty file reference namespace is then removed. To forcibly delete all objects, use flag force. The empty file reference namespace is then removed.
> 
> Derived from mel command maya.cmds.file

I didn't add the force flag, not sure if it should be added or just always passed as f=1.
