### PR TITLE
fix for getItemArray exceptions.

### DIFF
--- a/pymel/core/uitypes.py
+++ b/pymel/core/uitypes.py
@@ -796,11 +796,7 @@ class Menu(PyUI):
 
     def getItemArray(self):
         """ Modified to return pymel instances """
-        children = cmds.menu(self, query=True, itemArray=True)
-        if children:
-            return [MenuItem(item) for item in cmds.menu(self, query=True, itemArray=True)]
-        else:
-            return []
+        return [MenuItem(self + '|' + item) for item in cmds.menu(self, query=True, itemArray=True) or []]
 
     def makeDefault(self):
         """


### PR DESCRIPTION
Menu.getItemArray almost always throws an exception because it just returns the short name, passing in the full name seems to correct the problem.
Also tweaked the code a bit so only one call to cmds.menu is needed.
