### PR TITLE
Fix for #346

### DIFF
--- a/pymel/core/system.py
+++ b/pymel/core/system.py
@@ -1881,6 +1881,7 @@ Modifications:
     - returns empty string, for consistency with sceneName()
       ...if you wish to know the untitled scene name, use untitledFileName()
     """
+    kwargs.pop('type', kwargs.pop('typ', None))
     cmds.file(**kwargs)
     return ''
 


### PR DESCRIPTION
Fixes #346 
Pops the type and typ flags from kwargs before calling cmds.file.
You can still crash maya manually by going through cmds.file, but at
least pymel is a bit less crashy.