### PR TITLE
Adding isModified function.

### DIFF
--- a/pymel/core/system.py
+++ b/pymel/core/system.py
@@ -1949,6 +1949,9 @@ def saveAs(newname, **kwargs):
     cmds.file(**kwargs)
     return Path(newname)
 
+def isModified():
+    return cmds.file(q=True, modified=True)
+
 # ReferenceCache.setupFileReferenceCallbacks()
 
 #createReference = _factories.make_factories.createflagCmd( 'createReference', cmds.file, 'reference', __name__, returnFunc=FileReference )


### PR DESCRIPTION
Currently there is no way from pymel to query whether the current scene
has been modified, because pymel doesn't allow direct access to the
`file` cmd.

