### PR TITLE
Adding listDefault method to Attribute class

### DIFF
--- a/pymel/core/general.py
+++ b/pymel/core/general.py
@@ -3785,6 +3785,8 @@ class Attribute(PyNode):
             except TypeError:
                 return False
 
+    def listDefault(self):
+        return cmds.attributeQuery(self.attrName(), node=self.node(), listDefault=True)
 #}
 #--------------------------
 # xxx{ Ranges


### PR DESCRIPTION
Provides a solution to #400 

`cmds.addAttr` didn't seem like a clean way to implement this, as it only works on attribute created with `cmds.addAttr` and you have to query compound attributes individually.

So I used `cmds.attributeQuery` instead.

It needs a bit more work to wrap compound objects properly, but wanted to see if this was the right direction to go before putting any major time into it.