### PR TITLE
Allow optionvars to save long types

### DIFF
--- a/pymel/core/language.py
+++ b/pymel/core/language.py
@@ -505,7 +505,7 @@ class OptionVarList(tuple):
 
         if isinstance(val, basestring):
             return cmds.optionVar(stringValueAppend=[self.key, val])
-        if isinstance(val, int):
+        if isinstance(val, (int, long)):
             return cmds.optionVar(intValueAppend=[self.key, val])
         if isinstance(val, float):
             return cmds.optionVar(floatValueAppend=[self.key, val])
@@ -556,7 +556,7 @@ class OptionVarDict(collections.MutableMapping):
     def __setitem__(self, key, val):
         if isinstance(val, basestring):
             return cmds.optionVar(stringValue=[key, val])
-        if isinstance(val, (int, bool)):
+        if isinstance(val, (int, bool, long)):
             return cmds.optionVar(intValue=[key, int(val)])
         if isinstance(val, float):
             return cmds.optionVar(floatValue=[key, val])
@@ -566,7 +566,7 @@ class OptionVarDict(collections.MutableMapping):
             listType = type(val[0])
             if issubclass(listType, basestring):
                 flag = 'stringValue'
-            elif issubclass(listType, int):
+            elif issubclass(listType, (int, long)):
                 flag = 'intValue'
             elif issubclass(listType, float):
                 flag = 'floatValue'
@@ -749,7 +749,7 @@ class Mel(object):
 
     """Acts as a namespace from which MEL procedures can be called as if they
     were python functions.
-    
+
     Automatically formats python arguments into a command string which is
     executed via ``maya.mel.eval``.  An instance of this class is created for
     you as `pymel.core.mel`.


### PR DESCRIPTION
OptionVar lists are a little wonky right now.
```
>>> import pymel.core as pm
>>> pm.env.optionVars['int_test'] = [1, 2, 3]
>>> pm.env.optionVars['int_test']
(1L, 2L, 3L)

>>> pm.env.optionVars['int_test'].append(2)
(1L, 2L, 3L, 2L)
```
Everything is working fine so far, but...
```
>>> pm.env.optionVars['int_test'] = pm.env.optionVars['int_test']
Traceback (most recent call last):
  File "<sublime_code>", line 2, in <module>
  File "/usr/autodesk/maya2018/lib/python2.7/site-packages/pymel/core/language.py", line 574, in __setitem__
    raise TypeError, ('%r is unsupported; Only strings, ints, float, lists, and their subclasses are supported' % listType)
TypeError: <type 'long'> is unsupported; Only strings, ints, float, lists, and their subclasses are supported
```
This is obviously not ideal when you try to modify existing optionvar lists.

By the way, is there any reason why OptionVarList is a tuple (other than terrible performance when doing anything aside from a clear/append)? I just cobbled together a mutable version for myself, and I'd be happy to integrate it once I've written some tests.