### PR TITLE
Fix for parenting bug found in #406

### DIFF
--- a/pymel/core/general.py
+++ b/pymel/core/general.py
@@ -1378,7 +1378,7 @@ Modifications:
             children = nodes
         else:
             parent = PyNode(nodes[-1])
-            children = nodes[:-1]
+            children = nodes[0]
 
         # if you try to parent to the current parent, maya errors...
         # check for this and return if that's the case


### PR DESCRIPTION
The slicing syntax was creating a single element sequence that contained a sequence of child nodes. When that sequence was passed into the PyNode constructor, it would stringify it and throw an exception.