### PR TITLE
Fix for pymel.core.notetypes.Locator raising a value error.

### DIFF
--- a/pymel/core/general.py
+++ b/pymel/core/general.py
@@ -2405,6 +2405,8 @@ class PyNode(_util.ProxyUnicode):
                                 raise ValueError, "could not find type %s in result %s returned by %s" % (cls.__name__, res, cls.__melcmd__.__name__)
                         elif cls.__melnode__ == nodeType(res):  # isinstance(res,cls):
                             newNode = res
+                        elif hasattr(res, 'getShape') and cls.__melnode__ == nodeType(res.getShape()):
+                            newNode = res.getShape()
                         else:
                             raise ValueError, "unexpect result %s returned by %s" % (res, cls.__melcmd__.__name__)
                 else:


### PR DESCRIPTION
Currently `pymel.core.notetypes.Locator` returns a `ValueError` as the return type from `pymel.core.nodetypes.Locator.__melcmd__` is a single `Transform` object.
Which fails both the test to see if it a list, or that it matches `pymel.core.nodetypes.Locator.__melnode__`.

This adds an extra check to see if the shape on the returned object has a matching node type, and if so to use the shape instead of the transform.

All related tests passed, not sure if a test case is warranted for this or not, though I can add one if needed.