### PR TITLE
Fixes bug of display layer removing the members

### DIFF
--- a/pymel/core/nodetypes.py
+++ b/pymel/core/nodetypes.py
@@ -2474,8 +2474,8 @@ class DisplayLayer(DependNode):
     def addMembers(self, members, noRecurse=True):
         cmds.editDisplayLayerMembers(self, members, noRecurse=noRecurse)
 
-    def removeMembers(self, members):
-        cmds.editDisplayLayerMembers(self, members, remove=True)
+    def removeMembers(self, members, noRecurse=True):
+        cmds.editDisplayLayerMembers('defaultLayer', members, noRecurse=noRecurse)
 
     def setCurrent(self):
         cmds.editDisplayLayerMembers(currentDisplayLayer=self)


### PR DESCRIPTION
In class DisplayLayer, the method removeMembers had a bug, since maya discontinued cmds.editDisplayLayerMembers's remove argument. In order to make this method work i added a work around.