### PR TITLE
Use re.Pattern for python 3.7 compatibility and fallback to re._pattern_type in older versions.

### DIFF
--- a/maintenance/apiparser_compare.py
+++ b/maintenance/apiparser_compare.py
@@ -30,6 +30,11 @@ except ImportError:
     isOld = True
     XmlApiDocParser = HtmlApiDocParser = None
 
+try:
+    from re import Pattern as pattern_type
+except ImportError:
+    from re import _pattern_type as pattern_type
+
 import pymel.api as api
 
 
@@ -321,7 +326,7 @@ class RemoveEmptyEnumDocs(Transform):
 
 class RegexpTransform(IterTransform):
     def __init__(self, find, replace, keyFilter=None):
-        if not isinstance(find, re._pattern_type):
+        if not isinstance(find, pattern_type):
             find = re.compile(find)
         self.find = find
         self.replace = replace

--- a/pymel/core/general.py
+++ b/pymel/core/general.py
@@ -26,6 +26,11 @@ from maya.cmds import about as _about
 from pymel.internal import getLogger as _getLogger
 from pymel.util.enum import Enum
 
+try:
+    from re import Pattern as pattern_type
+except ImportError:
+    from re import _pattern_type as pattern_type
+
 if False:
     from typing import *
     import pymel.core.nodetypes as nodetypes
@@ -1201,7 +1206,7 @@ def ls(*args, **kwargs):
             if not val.endswith('$'):
                 val = val + '$'
             val = re.compile('(\||^)' + val)
-        elif not isinstance(val, re._pattern_type):
+        elif not isinstance(val, pattern_type):
             raise TypeError('regex flag must be passed a valid regex string, '
                             'a compiled regex object, or a list of these '
                             'types. got %s' % type(val).__name__)

--- a/pymel/util/path.py
+++ b/pymel/util/path.py
@@ -91,6 +91,11 @@ try:
 except AttributeError:
     getcwdu = os.getcwd
 
+try:
+    from re import Pattern as pattern_type
+except ImportError:
+    from re import _pattern_type as pattern_type
+
 if sys.version < '3':
     def u(x):
         return codecs.unicode_escape_decode(x)[0]
@@ -747,7 +752,7 @@ class path(unicode):
 
         .. seealso:: :meth:`fnmatch` and :meth:`regmatch`
         """
-        if isinstance(pattern, re._pattern_type):
+        if isinstance(pattern, pattern_type):
             return self.regmatch(pattern, normcase)
         else:
             return self.fnmatch(pattern, normcase)


### PR DESCRIPTION
Fixes #429 