### PR TITLE
Add instructions for using mypy stubgen to generate .pyi files

### DIFF
--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -238,7 +238,22 @@ Indicated by this error:
     this should be done)
 
 
-## 6) Build Stubs
+## 6) Build Stubs (new)
+
+  - Fix up the mypy typeshed. This is only required until my fixes to mypy stubgen
+    get officially released (at which point the requirements.txt file in this
+    directory will be updated and this note will be removed:
+    ```
+    git clone http://github.com/python/typeshed $(mayapy -c "import mypy,os;print(os.path.join(mypy.__path__[0], 'typeshed'))"
+    ```
+
+  - run `genstubs.sh`:
+    ```
+    maintenance/genstubs.sh
+    ```
+    The resulting .pyi files will get packaged up by poetry.
+
+## 6) Build Stubs (deprecated)
 
   - from a clean/default environment maya gui, run:
 

--- a/maintenance/genstubs.sh
+++ b/maintenance/genstubs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DIRNAME=`dirname $0`
+cd `dirname $DIRNAME`
+
+# remove existing stubs
+# stubgen causes problems when writing over top of existing .pyi files that live
+# in the source (it produces pyi files for packages, e.g. pymel/core.pyi)
+find pymel/ -name '*.pyi' -exec rm -f {} \;
+# build the stubs
+mayapy -m mypy.stubgen --no-import -o ./ pymel/*.py pymel/api pymel/core pymel/internal pymel/util

--- a/maintenance/requirements.txt
+++ b/maintenance/requirements.txt
@@ -3,3 +3,6 @@ pytest
 sphinx >=1.2.3, <1.3
 sphinx_rtd_theme
 sphinxcontrib-napoleon
+# includes a necessary fix, but it's not released yet
+#mypy >= 0.790
+https://github.com/chadrik/mypy/archive/stubgen-overload.zip


### PR DESCRIPTION
Summary of changes:

1. replace function factories with decorators where possible, so that `stubgen` knows these are functions instead of `Any`, and change the code gen proces to skip generating these lines when a decorated version of the function is present.
1. change the way imports are declared in `pymel/core/__init__.py` so that `stubgen` creates imports correctly
1. update the release process notes


Note that functions that are generated like this:

```python
animView = _factories.getCmdFunc('animView')
```

... are still generating lines like this in the .pyi stubs:

```python
animView: Any
```

I started working on some more changes to `stubgen` to recognize when a function returns a function, to improve these situations, but it got pretty hairy. 

