### PR TITLE
Keep reference to original module in LazyLoadModule

### DIFF
--- a/pymel/util/utilitytypes.py
+++ b/pymel/util/utilitytypes.py
@@ -635,11 +635,14 @@ class LazyLoadModule(types.ModuleType):
         types.ModuleType.__init__(self, name)
         self.__dict__.update(contents)
         self._lazyGlobals = contents  # globals of original module
+        # keep a reference to the original module so all values in its __dict__
+        # are not set to None by the module destructor when sys.modules[name] is
+        # the last reference to it and is replaced below, this prevents any
+        # problems where another reference to the original module exists (such
+        # as in a PEP-302 loader)
+        self._lazyModule = sys.modules.get(name)
         # add ourselves to sys.modules, overwriting the original module
         sys.modules[name] = self
-        # the above line assigns a None value to all entries in the original globals.
-        # luckily, we have a copy on this module we can use to restore it.
-        self._lazyGlobals.update(self.__dict__)
 
     def __dir__(self):
         # for modules, dir usually only returns what's in the dict, and does


### PR DESCRIPTION
This is so all values in __dict__ of original module are not set to None by the module destructor when sys.modules[name] is the last reference to the original module, and is replaced during LazyLoadModule.__init__. This prevents any problems where another reference to the original module exists (such as in a PEP-302 loader).

This is a somewhat obscure problem, but I did encounter it as I am using a PEP-302 loader in Maya, and it took a couple of days to figure out. I have updated the loader to ensure no reference to the module is kept during module execution, but this also seems like a useful update to pymel.