### PR TITLE
Fix exception in _pluginLoaded

### DIFF
--- a/pymel/core/__init__.py
+++ b/pymel/core/__init__.py
@@ -252,6 +252,7 @@ def _pluginLoaded(*args):
                     api.MEventMessage.removeCallback(id)
                     if hasattr(id, 'disown'):
                         id.disown()
+                    _pluginData[pluginName]['callbackId'] = None
 
             _pluginData[pluginName]['dependNodes'] = []
             allTypes = set(cmds.ls(nodeTypes=1))

--- a/pymel/core/__init__.py
+++ b/pymel/core/__init__.py
@@ -188,8 +188,13 @@ def _pluginLoaded(*args):
     global _pluginData
 
     if len(args) > 1:
-        # 2009 API callback, the args are ( [ pathToPlugin, pluginName ], clientData )
-        pluginName = args[0][1]
+        if len(args[0]) > 2:
+            # 2022 API callback, the args are ( [ pathToPlugin, pluginName1, pluginName2 ], clientData )
+            # pluginName2 is the old pluginName and is "" if the plugin was already loaded.
+            pluginName = args[0][2]
+        else:
+            # 2009 API callback, the args are ( [ pathToPlugin, pluginName ], clientData )
+            pluginName = args[0][1]
     else:
         pluginName = args[0]
     pluginName = _stripPluginExt(pluginName)


### PR DESCRIPTION
An exception is raised if a module was loaded during scene load, and something later attempts to load the module again in the future.  For example, if a scene requires stereoCamera, and you then open the Create > Cameras menu, the menu will loadModule -qt 1 "stereoCamera.mll" each time it's opened.  Each time will raise an exception:

// Error: file: C:/Program Files/Autodesk/Maya2022/scripts/startup/ModCreateMenu.mel line 1041: (kInvalidParameter): No element at given index
# Traceback (most recent call last):
#   File "C:\Users\glenn\AppData\Roaming\Python\Python37\site-packages\pymel\core\__init__.py", line 213, in _pluginLoaded
#     api.MEventMessage.removeCallback(_pluginData[pluginName]['callbackId'])
# RuntimeError: (kInvalidParameter): No element at given index // 
// Warning: file: C:/Program Files/Autodesk/Maya2022/scripts/startup/ModCreateMenu.mel line 1041: Python callback failed // 

This happens in 2020 and 2022.  In 2020 it only happened if loadPlugin's -qt (quiet) argument was 0.  In 2022 it happens even if it's true, which is why the Create > Cameras menu is triggering it.

This fixes two parts:

- pymel.core._pluginLoaded's addPluginPyNodes removes the callback, but it leaves callbackId in place, so the later MEventMessage.removeCallback raises an exception when it tries to remove a callback that was already removed.
- MSceneMessage.kAfterPluginLoad now has three arguments in 2022 instead of two.  This part is strange:
  In 2020, the arguments were [pluginPath, pluginFilename].
  In 2022, the arguments are [pluginPath, pluginName, pluginFilename], with the extra pluginName (name without extension) in between.
  In both versions, pluginFilename is "" if the plugin was already loaded (it wasn't actually just loaded), *and* loadPlugin was called with -qt 1.  The new pluginName argument doesn't do this.  This is why this only happened in 2020 with -qt 0 (with -qt 1 then the "if not pluginName" check would short-circuit), and why it always happens in 2022 (pluginName is never empty).

This does mean that loadPlugin -qt 0 will still re-process the plugin load unnecessarily and -qt 1 won't.  This could probably be avoided by stopping if _pluginData[pluginName] already exists, but I haven't done that here.

(This callback change seems to be undocumented, I'll file a bug.  It also feels like a bug that the pluginName argument changes depending on the -qt flag in the first place...)

Tested in Maya 2020 and 2022.
