### PR TITLE
Fix dir() for PyNode subclasses in Python 3

### DIFF
--- a/pymel/util/utilitytypes.py
+++ b/pymel/util/utilitytypes.py
@@ -487,7 +487,7 @@ else:
 ProxyUnicode = proxyClass(
     _proxyStrBase, 'ProxyUnicode',
     module=__name__, dataFuncName='name',
-    remove=['__doc__', '__getslice__', '__contains__', '__len__',
+    remove=['__doc__', '__getslice__', '__contains__', '__len__', '__dir__',
             '__mod__', '__rmod__', '__mul__', '__rmod__', '__rmul__',  # reserved for higher levels
             'expandtabs', 'translate', 'decode', 'encode', 'splitlines',
             'capitalize', 'swapcase', 'title',


### PR DESCRIPTION
Python 3 has a __dir__ on str, which means any class that subclasses it will show
wrong results for dir().  Work around this by removing str.__dir__ from ProxyUnicode
so it uses the normal default behavior.

Before, the output of print(dir(pm.PyNode('persp'))) was the same as dir('').  This
brings it back to what it was in Python 2.