### PR TITLE
docs: Fix a few typos

### DIFF
--- a/maintenance/build.py
+++ b/maintenance/build.py
@@ -683,7 +683,7 @@ class Conditional(Statement):
             return 'versions.current() >= {}'.format(minTrue)
         elif all(x < versionsTrue[0] or x > versionsTrue[-1]
                  for x in versionsFalse):
-            # now see if trueVersions forms a "continuous range", not interruped
+            # now see if trueVersions forms a "continuous range", not interrupted
             # by any false versions
             lowerBound = VersionedCaches.symbolicVersionName(versionsTrue[0])
             # since versionsFalse is sorted, the first one we find > maxTrue
@@ -696,7 +696,7 @@ class Conditional(Statement):
                 lowerBound, upperBound)
         elif all(x < versionsFalse[0] or x > versionsFalse[-1]
                  for x in versionsTrue):
-            # now see if falseVersions forms a "continuous range", not interruped
+            # now see if falseVersions forms a "continuous range", not interrupted
             # by any true versions
             lowerBound = VersionedCaches.symbolicVersionName(versionsFalse[0])
             # since versionsTrue is sorted, the first one we find > maxFalse

--- a/maintenance/stubs.py
+++ b/maintenance/stubs.py
@@ -170,7 +170,7 @@ def get_unique_name(basename=None, all_names=()):
     if basename is None:
         basename = '_unknown'
     elif not basename.startswith('_'):
-        # we only use this in cases where the name wasn't orignally
+        # we only use this in cases where the name wasn't originally
         # found in the module - ie, we're just trying to add in
         # something that isn't really supposed to be in the module, but
         # we need it there to refer to it...

--- a/pymel/core/general.py
+++ b/pymel/core/general.py
@@ -7771,7 +7771,7 @@ class AttributeSpec(with_metaclass(_factories.MetaMayaTypeRegistry, PyNode)):
     the same - ie, they are all floating point numerical attributes, are all
     storable, etc.
 
-    For those familar with the API, an Attribute wraps an MPlug, while an
+    For those familiar with the API, an Attribute wraps an MPlug, while an
     AttributeSpec wraps MFnAttribute.
     '''
     __slots__ = ()

--- a/pymel/internal/apicache.py
+++ b/pymel/internal/apicache.py
@@ -1230,7 +1230,7 @@ class ApiCache(BaseApiClassInfoCache):
 
         return reservedMayaTypes
 
-    # TODO: eventually, would like to move the node-heirarchy-building stuff
+    # TODO: eventually, would like to move the node-hierarchy-building stuff
     # from cmdcache into here... we could then cache the node inheritance info,
     # instead of constantly re-querying it in various places...
     def _buildMayaNodeInfo(self):

--- a/pymel/internal/factories.py
+++ b/pymel/internal/factories.py
@@ -3453,7 +3453,7 @@ def addCustomPyNode(module, mayaType, extraAttrs=None):
         _logger.warning("could not get inheritance for mayaType %s" % mayaType)
     else:
         #__logger.debug(mayaType, inheritance)
-        #__logger.debug("adding new node:", mayaType, apiEnum, inheritence)
+        #__logger.debug("adding new node:", mayaType, apiEnum, inheritance)
         # some nodes in the hierarchy for this node might not exist, so we cycle through all
         parent = 'dependNode'
 

--- a/pymel/util/objectParser.py
+++ b/pymel/util/objectParser.py
@@ -163,7 +163,7 @@ class Parsed(ProxyUni):
             errmsg = "cannot parse '%s' to a valid %s, %d parser errors" % (data, clsname, cls.classparser().errorcount)
             isValid = False
         elif not isinstance(result, cls):
-            # parse successful but returned a different class than exected
+            # parse successful but returned a different class than expected
             errmsg = "parsing '%s' is valid, but as a %s Parsed object, and not as a %s Parsed object as it was parsed against" % (data, result.__class__.__name__, clsname)
             isValid = False
         elif not result == data:

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -1367,7 +1367,7 @@ class test_PMTypes(unittest.TestCase):
         self.assertEqual(self.o.formated(),'[[1.0, 0.0, 0.0, 0.0],\n [0.0, 1.0, 0.0, 0.0],\n [0.0, 0.0, 1.0, 0.0],\n [0.0, 0.0, 0.0, 1.0]]')
 
     def test_constants(self):
-        # TODO : come up with a programatic way of finding constants
+        # TODO : come up with a programmatic way of finding constants
         s = """
         Vector.xAxis
         Vector.one

--- a/tests/test_nodetypes.py
+++ b/tests/test_nodetypes.py
@@ -700,7 +700,7 @@ class TestInvertibles(object):
 # test tricky / extended slices: ie, [:3], [:-1], [-3:-1], [5:1:-2], etc
 # test multi-index slices, ie: [1:2, 5:9:2]
 # Add tests for ranges of float parameters: ie, 'nurbsSphere1.v[5.657][3.1:4.2]'
-# Add tests for double-indexed nurbs suface: 'nurbsSphere1.v[1.1:2.2][3.3:4.4]'
+# Add tests for double-indexed nurbs surface: 'nurbsSphere1.v[1.1:2.2][3.3:4.4]'
 # check that indexing uses mel-style ranges (ie, inclusive)
 # Continuous components with negative indices - ie, nurbsSurf[-3.3][-2]
 
@@ -1904,7 +1904,7 @@ class testCase_components(unittest.TestCase):
             self.fail('Following components did not yield expected components:\n   ' + '\n   '.join(failedComps))
 
     def test_negativeContinuousIndices(self):
-        # For continous comps, these should behave just like positive ones...
+        # For continuous comps, these should behave just like positive ones...
         failedComps = []
         def check(pynode, expectedStrings, compData):
             if not self.compsEqual(pynode, expectedStrings, compData):


### PR DESCRIPTION
There are small typos in:
- maintenance/build.py
- maintenance/stubs.py
- pymel/core/general.py
- pymel/internal/apicache.py
- pymel/internal/factories.py
- pymel/util/objectParser.py
- tests/test_datatypes.py
- tests/test_nodetypes.py

Fixes:
- Should read `interrupted` rather than `interruped`.
- Should read `surface` rather than `suface`.
- Should read `programmatic` rather than `programatic`.
- Should read `originally` rather than `orignally`.
- Should read `inheritance` rather than `inheritence`.
- Should read `hierarchy` rather than `heirarchy`.
- Should read `familiar` rather than `familar`.
- Should read `expected` rather than `exected`.
- Should read `continuous` rather than `continous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md