### PR TITLE
Fix problems with ProxyUni in Python 3 caused by __iter__

### DIFF
--- a/pymel/util/objectParser.py
+++ b/pymel/util/objectParser.py
@@ -62,7 +62,7 @@ class ParsingWarning(UserWarning):
     pass
 
 
-ProxyUni = proxyClass(str, 'ProxyUni', module=__name__, dataFuncName='compileName', remove=['__getitem__', '__doc__'])  # 2009 Beta 2.1 has issues with passing classes with __getitem__
+ProxyUni = proxyClass(str, 'ProxyUni', module=__name__, dataFuncName='compileName', remove=['__getitem__', '__doc__', '__iter__'])  # 2009 Beta 2.1 has issues with passing classes with __getitem__
 
 # For parsed objects, Token or upper level constructs
 


### PR DESCRIPTION
I encountered an issue using the `force` parameter for `pymel.core.setAttr`.  I was getting this error:

```
Invalid arguments for flag 'ln'. Expected string, got ( str, str, str, str, str, str, str )
```

The error seemed to be referring to the attribute name, which had 7 characters ("comment"), because this error seems to indicate that the attribute name was, at some point, converted into a 7-tuple.  Long story short, the string is being misinterpreted as a sequence and is treated as one, instead of a string.

I tracked this down to `pymel.core.util.isIterable` which checks if the object is iterable by running `iter` on it.  Removing the `__iter__` method from `ProxyUni` fixed this error.  A strange solution but it was the simplest one.