### PR TITLE
Maya 2023 introduced a breaking change for the editorTemplate() funct…

### DIFF
--- a/pymel/core/uitypes.py
+++ b/pymel/core/uitypes.py
@@ -4025,7 +4025,7 @@ class AETemplate(with_metaclass(AELoader, object)):
             replaceFunc = pymel.tools.py2mel.py2melProc(
                 replaceFunc, procName=name, argTypes=['string'] * len(attrs))
         args = (newFunc, replaceFunc) + attrs
-        cmds.editorTemplate(callCustom=1, *args)
+        cmds.editorTemplate(*args, callCustom=1)
 
     def suppress(self, control):
         cmds.editorTemplate(suppress=control)


### PR DESCRIPTION
…ion that now expects the arguments to be passed in first before adding the callCustom flag. Without this fix, the callCustom() method will not do anything and thus breaking AETemplates that depends on it.