### PR TITLE
Fixed a bug in pymel.core.uitypes.AELoader.load() caused by upgrading to Python 3

### DIFF
--- a/pymel/core/uitypes.py
+++ b/pymel/core/uitypes.py
@@ -3907,7 +3907,7 @@ class AELoader(type):
 
     @staticmethod
     def load(modname, classname, nodename):
-        mod = __import__(modname, globals(), locals(), [classname], -1)
+        mod = __import__(modname, globals(), locals(), [classname])
         try:
             cls = getattr(mod, classname)
             cls(nodename)


### PR DESCRIPTION
In Python 3, the last argument for `__import__()` cannot be negative and thus raising an error. Since the idea is to use the default value (which was `-1` in Python 2) we can do the same by simply removing the argument.