### PR TITLE
"False" UI.menu creation fix

### DIFF
--- a/pymel/core/windows.py
+++ b/pymel/core/windows.py
@@ -1853,6 +1853,8 @@ def menu(*args, **kwargs):
         except KeyError:
             pass
     res = _menu(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.Menu)
     return res

--- a/pymel/core/windows.py
+++ b/pymel/core/windows.py
@@ -851,6 +851,8 @@ def attrColorSliderGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.attrColorSliderGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.AttrColorSliderGrp)
     return res
@@ -870,6 +872,8 @@ def attrControlGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.attrControlGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.AttrControlGrp)
     return res
@@ -889,6 +893,8 @@ def attrEnumOptionMenu(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.attrEnumOptionMenu(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.AttrEnumOptionMenu)
     return res
@@ -908,6 +914,8 @@ def attrEnumOptionMenuGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.attrEnumOptionMenuGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.AttrEnumOptionMenuGrp)
     return res
@@ -927,6 +935,8 @@ def attrFieldGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.attrFieldGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.AttrFieldGrp)
     return res
@@ -946,6 +956,8 @@ def attrFieldSliderGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.attrFieldSliderGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.AttrFieldSliderGrp)
     return res
@@ -965,6 +977,8 @@ def attrNavigationControlGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.attrNavigationControlGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.AttrNavigationControlGrp)
     return res
@@ -1003,6 +1017,8 @@ def colorIndexSliderGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.colorIndexSliderGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ColorIndexSliderGrp)
     return res
@@ -1022,6 +1038,8 @@ def colorSliderButtonGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.colorSliderButtonGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ColorSliderButtonGrp)
     return res
@@ -1041,6 +1059,8 @@ def colorSliderGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.colorSliderGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ColorSliderGrp)
     return res
@@ -1060,6 +1080,8 @@ def columnLayout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.columnLayout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ColumnLayout)
     return res
@@ -1087,6 +1109,8 @@ def floatField(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.floatField(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.FloatField)
     return res
@@ -1106,6 +1130,8 @@ def floatFieldGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.floatFieldGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.FloatFieldGrp)
     return res
@@ -1125,6 +1151,8 @@ def floatScrollBar(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.floatScrollBar(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.FloatScrollBar)
     return res
@@ -1144,6 +1172,8 @@ def floatSlider(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.floatSlider(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.FloatSlider)
     return res
@@ -1163,6 +1193,8 @@ def floatSlider2(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.floatSlider2(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.FloatSlider2)
     return res
@@ -1182,6 +1214,8 @@ def floatSliderButtonGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.floatSliderButtonGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.FloatSliderButtonGrp)
     return res
@@ -1201,6 +1235,8 @@ def floatSliderGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.floatSliderGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.FloatSliderGrp)
     return res
@@ -1220,6 +1256,8 @@ def frameLayout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.frameLayout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.FrameLayout)
     return res
@@ -1239,6 +1277,8 @@ def iconTextButton(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.iconTextButton(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.IconTextButton)
     return res
@@ -1258,6 +1298,8 @@ def iconTextCheckBox(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.iconTextCheckBox(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.IconTextCheckBox)
     return res
@@ -1277,6 +1319,8 @@ def iconTextRadioButton(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.iconTextRadioButton(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.IconTextRadioButton)
     return res
@@ -1296,6 +1340,8 @@ def iconTextRadioCollection(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.iconTextRadioCollection(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.IconTextRadioCollection)
     return res
@@ -1315,6 +1361,8 @@ def iconTextScrollList(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.iconTextScrollList(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.IconTextScrollList)
     return res
@@ -1334,6 +1382,8 @@ def iconTextStaticLabel(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.iconTextStaticLabel(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.IconTextStaticLabel)
     return res
@@ -1353,6 +1403,8 @@ def intField(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.intField(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.IntField)
     return res
@@ -1372,6 +1424,8 @@ def intFieldGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.intFieldGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.IntFieldGrp)
     return res
@@ -1391,6 +1445,8 @@ def intScrollBar(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.intScrollBar(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.IntScrollBar)
     return res
@@ -1410,6 +1466,8 @@ def intSlider(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.intSlider(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.IntSlider)
     return res
@@ -1429,6 +1487,8 @@ def intSliderGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.intSliderGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.IntSliderGrp)
     return res
@@ -1448,6 +1508,8 @@ def paneLayout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.paneLayout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.PaneLayout)
     return res
@@ -1467,6 +1529,8 @@ def panel(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.panel(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.Panel)
     return res
@@ -1486,6 +1550,8 @@ def radioButton(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.radioButton(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.RadioButton)
     return res
@@ -1505,6 +1571,8 @@ def radioButtonGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.radioButtonGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.RadioButtonGrp)
     return res
@@ -1513,6 +1581,8 @@ def radioButtonGrp(*args, **kwargs):
 def radioCollection(*args, **kwargs):
     from . import uitypes
     res = cmds.radioCollection(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.RadioCollection)
     return res
@@ -1521,6 +1591,8 @@ def radioCollection(*args, **kwargs):
 def radioMenuItemCollection(*args, **kwargs):
     from . import uitypes
     res = cmds.radioMenuItemCollection(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.RadioMenuItemCollection)
     return res
@@ -1540,6 +1612,8 @@ def symbolButton(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.symbolButton(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.SymbolButton)
     return res
@@ -1559,6 +1633,8 @@ def symbolCheckBox(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.symbolCheckBox(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.SymbolCheckBox)
     return res
@@ -1586,6 +1662,8 @@ def textField(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.textField(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.TextField)
     return res
@@ -1605,6 +1683,8 @@ def textFieldButtonGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.textFieldButtonGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.TextFieldButtonGrp)
     return res
@@ -1624,6 +1704,8 @@ def textFieldGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.textFieldGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.TextFieldGrp)
     return res
@@ -1643,6 +1725,8 @@ def text(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.text(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.Text)
     return res
@@ -1662,6 +1746,8 @@ def textScrollList(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.textScrollList(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.TextScrollList)
     wraps = _factories.simpleCommandWraps['textScrollList']
@@ -1686,6 +1772,8 @@ def toolButton(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.toolButton(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ToolButton)
     return res
@@ -1694,6 +1782,8 @@ def toolButton(*args, **kwargs):
 def toolCollection(*args, **kwargs):
     from . import uitypes
     res = cmds.toolCollection(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ToolCollection)
     return res
@@ -1713,6 +1803,8 @@ def window(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.window(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.Window)
     return res
@@ -1721,6 +1813,8 @@ def window(*args, **kwargs):
 def blendShapeEditor(*args, **kwargs):
     from . import uitypes
     res = cmds.blendShapeEditor(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.BlendShapeEditor)
     return res
@@ -1740,6 +1834,8 @@ def blendShapePanel(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.blendShapePanel(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.BlendShapePanel)
     return res
@@ -1759,6 +1855,8 @@ def button(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.button(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.Button)
     return res
@@ -1778,6 +1876,8 @@ def checkBox(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.checkBox(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.CheckBox)
     return res
@@ -1797,6 +1897,8 @@ def checkBoxGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.checkBoxGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.CheckBoxGrp)
     return res
@@ -1832,6 +1934,8 @@ def formLayout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.formLayout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.FormLayout)
     return res
@@ -1874,6 +1978,8 @@ def menuBarLayout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.menuBarLayout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.MenuBarLayout)
     return res
@@ -1893,6 +1999,8 @@ def menuEditor(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.menuEditor(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.MenuEditor)
     return res
@@ -1912,6 +2020,8 @@ def menuItem(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.menuItem(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.MenuItem)
     return res
@@ -1947,6 +2057,8 @@ def scrollField(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.scrollField(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ScrollField)
     return res
@@ -1966,6 +2078,8 @@ def scrollLayout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.scrollLayout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ScrollLayout)
     return res
@@ -1985,6 +2099,8 @@ def scriptedPanel(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.scriptedPanel(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ScriptedPanel)
     return res
@@ -1993,6 +2109,8 @@ def scriptedPanel(*args, **kwargs):
 def scriptedPanelType(*args, **kwargs):
     from . import uitypes
     res = cmds.scriptedPanelType(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ScriptedPanelType)
     return res
@@ -2012,6 +2130,8 @@ def shelfButton(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.shelfButton(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ShelfButton)
     return res
@@ -2031,6 +2151,8 @@ def shelfLayout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.shelfLayout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ShelfLayout)
     return res
@@ -2050,6 +2172,8 @@ def shelfTabLayout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.shelfTabLayout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ShelfTabLayout)
     return res
@@ -2069,6 +2193,8 @@ def tabLayout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.tabLayout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.TabLayout)
     return res
@@ -2088,6 +2214,8 @@ def outlinerEditor(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.outlinerEditor(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.OutlinerEditor)
     return res
@@ -2107,6 +2235,8 @@ def optionMenu(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.optionMenu(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.OptionMenu)
     wraps = _factories.simpleCommandWraps['optionMenu']
@@ -2131,6 +2261,8 @@ def outlinerPanel(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.outlinerPanel(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.OutlinerPanel)
     return res
@@ -2150,6 +2282,8 @@ def optionMenuGrp(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.optionMenuGrp(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.OptionMenuGrp)
     wraps = _factories.simpleCommandWraps['optionMenuGrp']
@@ -2174,6 +2308,8 @@ def animCurveEditor(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.animCurveEditor(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.AnimCurveEditor)
     return res
@@ -2201,6 +2337,8 @@ def separator(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.separator(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.Separator)
     return res
@@ -2239,6 +2377,8 @@ def layout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.layout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.Layout)
     return res
@@ -2277,6 +2417,8 @@ def layerButton(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.layerButton(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.LayerButton)
     return res
@@ -2296,6 +2438,8 @@ def hyperGraph(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.hyperGraph(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.HyperGraph)
     return res
@@ -2315,6 +2459,8 @@ def hyperPanel(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.hyperPanel(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.HyperPanel)
     return res
@@ -2342,6 +2488,8 @@ def rowColumnLayout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.rowColumnLayout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.RowColumnLayout)
     return res
@@ -2361,6 +2509,8 @@ def rowLayout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.rowLayout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.RowLayout)
     return res
@@ -2380,6 +2530,8 @@ def renderWindowEditor(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.renderWindowEditor(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.RenderWindowEditor)
     return res
@@ -2388,6 +2540,8 @@ def renderWindowEditor(*args, **kwargs):
 def glRenderEditor(*args, **kwargs):
     from . import uitypes
     res = cmds.glRenderEditor(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.GlRenderEditor)
     return res
@@ -2409,6 +2563,8 @@ def scriptTable(*args, **kwargs):
         except KeyError:
             pass
     res = _scriptTable(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ScriptTable)
     return res
@@ -2428,6 +2584,8 @@ def keyframeStats(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.keyframeStats(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.KeyframeStats)
     return res
@@ -2447,6 +2605,8 @@ def keyframeOutliner(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.keyframeOutliner(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.KeyframeOutliner)
     return res
@@ -2466,6 +2626,8 @@ def canvas(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.canvas(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.Canvas)
     return res
@@ -2485,6 +2647,8 @@ def channelBox(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.channelBox(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ChannelBox)
     return res
@@ -2504,6 +2668,8 @@ def gradientControl(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.gradientControl(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.GradientControl)
     return res
@@ -2523,6 +2689,8 @@ def gradientControlNoAttr(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.gradientControlNoAttr(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.GradientControlNoAttr)
     return res
@@ -2542,6 +2710,8 @@ def gridLayout(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.gridLayout(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.GridLayout)
     return res
@@ -2561,6 +2731,8 @@ def messageLine(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.messageLine(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.MessageLine)
     return res
@@ -2580,6 +2752,8 @@ def popupMenu(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.popupMenu(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.PopupMenu)
     return res
@@ -2599,6 +2773,8 @@ def modelEditor(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.modelEditor(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ModelEditor)
     wraps = _factories.simpleCommandWraps['modelEditor']
@@ -2623,6 +2799,8 @@ def modelPanel(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.modelPanel(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ModelPanel)
     return res
@@ -2642,6 +2820,8 @@ def helpLine(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.helpLine(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.HelpLine)
     return res
@@ -2661,6 +2841,8 @@ def hardwareRenderPanel(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.hardwareRenderPanel(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.HardwareRenderPanel)
     return res
@@ -2680,6 +2862,8 @@ def image(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.image(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.Image)
     return res
@@ -2699,6 +2883,8 @@ def nodeIconButton(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.nodeIconButton(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.NodeIconButton)
     return res
@@ -2718,6 +2904,8 @@ def commandLine(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.commandLine(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.CommandLine)
     return res
@@ -2737,6 +2925,8 @@ def progressBar(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.progressBar(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ProgressBar)
     return res
@@ -2756,6 +2946,8 @@ def defaultLightListCheckBox(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.defaultLightListCheckBox(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.DefaultLightListCheckBox)
     return res
@@ -2775,6 +2967,8 @@ def exclusiveLightCheckBox(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.exclusiveLightCheckBox(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ExclusiveLightCheckBox)
     return res
@@ -2794,6 +2988,8 @@ def clipSchedulerOutliner(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.clipSchedulerOutliner(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ClipSchedulerOutliner)
     return res
@@ -2802,6 +2998,8 @@ def clipSchedulerOutliner(*args, **kwargs):
 def clipEditor(*args, **kwargs):
     from . import uitypes
     res = cmds.clipEditor(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.ClipEditor)
     return res
@@ -2810,6 +3008,8 @@ def clipEditor(*args, **kwargs):
 def deviceEditor(*args, **kwargs):
     from . import uitypes
     res = cmds.deviceEditor(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.DeviceEditor)
     return res
@@ -2829,6 +3029,8 @@ def devicePanel(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.devicePanel(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.DevicePanel)
     return res
@@ -2848,6 +3050,8 @@ def dynPaintEditor(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.dynPaintEditor(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.DynPaintEditor)
     return res
@@ -2867,6 +3071,8 @@ def nameField(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.nameField(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.NameField)
     return res
@@ -2886,6 +3092,8 @@ def cmdScrollFieldExecuter(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.cmdScrollFieldExecuter(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.CmdScrollFieldExecuter)
     return res
@@ -2905,6 +3113,8 @@ def cmdScrollFieldReporter(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.cmdScrollFieldReporter(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.CmdScrollFieldReporter)
     return res
@@ -2924,6 +3134,8 @@ def cmdShell(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.cmdShell(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.CmdShell)
     return res
@@ -2943,6 +3155,8 @@ def nameField(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.nameField(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.NameField)
     return res
@@ -2962,6 +3176,8 @@ def palettePort(*args, **kwargs):
         except KeyError:
             pass
     res = cmds.palettePort(*args, **kwargs)
+    if kwargs.get('exists', kwargs.get('ex', False)):
+        return res
     if not kwargs.get('query', kwargs.get('q', False)):
         res = _factories.maybeConvert(res, uitypes.PalettePort)
     return res


### PR DESCRIPTION
Possible fix for issue [**#471**](https://github.com/LumaPictures/pymel/issues/471)

A way to circumvent this issue is to return `res` early in the case the `exists` arg is present.

I believe this to be safe since, according to the Maya Command Reference, it ignores any other args when `exists` is used and, therefore, is essentially equivalent to a call with the `query` arg.

Bellow is a list of all the cmds under [windows.py](https://github.com/LumaPictures/pymel/blob/master/pymel/core/windows.py) that contains the flag with the description:
```
exists(ex)
    Returns whether the specified object exists or not. Other flags are ignored.
```

[animCurveEditor](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/animCurveEditor.html#flagexists)
[attrColorSliderGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/attrColorSliderGrp.html#flagexists)
[attrControlGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/attrControlGrp.html#flagexists)
[attrEnumOptionMenu](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/attrEnumOptionMenu.html#flagexists)
[attrEnumOptionMenuGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/attrEnumOptionMenuGrp.html#flagexists)
[attrFieldGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/attrFieldGrp.html#flagexists)
[attrFieldSliderGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/attrFieldSliderGrp.html#flagexists)
[attrNavigationControlGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/attrNavigationControlGrp.html#flagexists)
[blendShapeEditor](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/blendShapeEditor.html#flagexists)
[blendShapePanel](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/blendShapePanel.html#flagexists)
[button](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/button.html#flagexists)
[canvas](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/canvas.html#flagexists)
[channelBox](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/channelBox.html#flagexists)
[checkBox](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/checkBox.html#flagexists)
[checkBoxGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/checkBoxGrp.html#flagexists)
[clipEditor](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/clipEditor.html#flagexists)
[clipSchedulerOutliner](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/clipSchedulerOutliner.html#flagexists)
[cmdScrollFieldExecuter](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/cmdScrollFieldExecuter.html#flagexists)
[cmdScrollFieldReporter](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/cmdScrollFieldReporter.html#flagexists)
[cmdShell](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/cmdShell.html#flagexists)
[colorIndexSliderGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/colorIndexSliderGrp.html#flagexists)
[colorSliderButtonGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/colorSliderButtonGrp.html#flagexists)
[colorSliderGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/colorSliderGrp.html#flagexists)
[columnLayout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/columnLayout.html#flagexists)
[commandLine](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/commandLine.html#flagexists)
[defaultLightListCheckBox](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/defaultLightListCheckBox.html#flagexists)
[deviceEditor](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/deviceEditor.html#flagexists)
[devicePanel](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/devicePanel.html#flagexists)
[dynPaintEditor](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/dynPaintEditor.html#flagexists)
[exclusiveLightCheckBox](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/exclusiveLightCheckBox.html#flagexists)
[floatField](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/floatField.html#flagexists)
[floatFieldGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/floatFieldGrp.html#flagexists)
[floatScrollBar](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/floatScrollBar.html#flagexists)
[floatSlider](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/floatSlider.html#flagexists)
[floatSlider2](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/floatSlider2.html#flagexists)
[floatSliderButtonGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/floatSliderButtonGrp.html#flagexists)
[floatSliderGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/floatSliderGrp.html#flagexists)
[formLayout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/formLayout.html#flagexists)
[frameLayout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/frameLayout.html#flagexists)
[glRenderEditor](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/glRenderEditor.html#flagexists)
[gradientControl](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/gradientControl.html#flagexists)
[gradientControlNoAttr](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/gradientControlNoAttr.html#flagexists)
[gridLayout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/gridLayout.html#flagexists)
[hardwareRenderPanel](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/hardwareRenderPanel.html#flagexists)
[helpLine](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/helpLine.html#flagexists)
[hyperGraph](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/hyperGraph.html#flagexists)
[hyperPanel](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/hyperPanel.html#flagexists)
[iconTextButton](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/iconTextButton.html#flagexists)
[iconTextCheckBox](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/iconTextCheckBox.html#flagexists)
[iconTextRadioButton](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/iconTextRadioButton.html#flagexists)
[iconTextRadioCollection](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/iconTextRadioCollection.html#flagexists)
[iconTextScrollList](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/iconTextScrollList.html#flagexists)
[iconTextStaticLabel](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/iconTextStaticLabel.html#flagexists)
[image](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/image.html#flagexists)
[intField](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/intField.html#flagexists)
[intFieldGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/intFieldGrp.html#flagexists)
[intScrollBar](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/intScrollBar.html#flagexists)
[intSlider](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/intSlider.html#flagexists)
[intSliderGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/intSliderGrp.html#flagexists)
[keyframeOutliner](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/keyframeOutliner.html#flagexists)
[keyframeStats](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/keyframeStats.html#flagexists)
[layerButton](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/layerButton.html#flagexists)
[layout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/layout.html#flagexists)
[menu](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/menu.html#flagexists)
[menuBarLayout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/menuBarLayout.html#flagexists)
[menuEditor](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/menuEditor.html#flagexists)
[menuItem](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/menuItem.html#flagexists)
[messageLine](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/messageLine.html#flagexists)
[modelEditor](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/modelEditor.html#flagexists)
[modelPanel](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/modelPanel.html#flagexists)
[nameField](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/nameField.html#flagexists)
[nameField](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/nameField.html#flagexists)
[nodeIconButton](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/nodeIconButton.html#flagexists)
[optionMenu](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/optionMenu.html#flagexists)
[optionMenuGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/optionMenuGrp.html#flagexists)
[outlinerEditor](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/outlinerEditor.html#flagexists)
[outlinerPanel](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/outlinerPanel.html#flagexists)
[palettePort](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/palettePort.html#flagexists)
[paneLayout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/paneLayout.html#flagexists)
[panel](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/panel.html#flagexists)
[popupMenu](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/popupMenu.html#flagexists)
[progressBar](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/progressBar.html#flagexists)
[radioButton](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/radioButton.html#flagexists)
[radioButtonGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/radioButtonGrp.html#flagexists)
[radioCollection](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/radioCollection.html#flagexists)
[radioMenuItemCollection](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/radioMenuItemCollection.html#flagexists)
[renderWindowEditor](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/renderWindowEditor.html#flagexists)
[rowColumnLayout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/rowColumnLayout.html#flagexists)
[rowLayout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/rowLayout.html#flagexists)
[scriptTable](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/scriptTable.html#flagexists)
[scriptedPanel](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/scriptedPanel.html#flagexists)
[scriptedPanelType](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/scriptedPanelType.html#flagexists)
[scrollField](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/scrollField.html#flagexists)
[scrollLayout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/scrollLayout.html#flagexists)
[separator](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/separator.html#flagexists)
[shelfButton](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/shelfButton.html#flagexists)
[shelfLayout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/shelfLayout.html#flagexists)
[shelfTabLayout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/shelfTabLayout.html#flagexists)
[symbolButton](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/symbolButton.html#flagexists)
[symbolCheckBox](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/symbolCheckBox.html#flagexists)
[tabLayout](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/tabLayout.html#flagexists)
[text](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/text.html#flagexists)
[textField](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/textField.html#flagexists)
[textFieldButtonGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/textFieldButtonGrp.html#flagexists)
[textFieldGrp](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/textFieldGrp.html#flagexists)
[textScrollList](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/textScrollList.html#flagexists)
[toolButton](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/toolButton.html#flagexists)
[toolCollection](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/toolCollection.html#flagexists)
[window](https://help.autodesk.com/cloudhelp/2022/ENU/Maya-Tech-Docs/CommandsPython/window.html#flagexists)